### PR TITLE
Links as object for JSON representation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject halresource "0.1.0-SNAPSHOT"
+(defproject halresource "0.2.0-SNAPSHOT"
   :description "halresource is a library for building and representing resources in Hypertext Application Format (http://stateless.co/hal_specification.html)."
   :url "https://github.com/cndreisbach/halresource"
   :license {:name "Unlicense"

--- a/src/halresource/resource.clj
+++ b/src/halresource/resource.clj
@@ -70,8 +70,10 @@
       xml/emit-str))
 
 (defn json-representation [resource]
-  (let [links (-> [{:rel "self" :href (:href resource)}]
-                  (concat (:links resource)))
+  (let [links (into {"self" {"href" (:href resource)}}
+                    (for [[k link] (group-by :rel (:links resource))]
+                      (letfn [(remove-rel [l] (dissoc l :rel))]
+                        [k (if (= 1 (count link)) (remove-rel (first link)) (map remove-rel link))])))
         embedded (into {}
                        (map (fn [[k resources]]
                               [(plural k)

--- a/test/halresource/resource_test.clj
+++ b/test/halresource/resource_test.clj
@@ -69,16 +69,6 @@
                              "admin" {"href" "/admin"}
                              "next" {"href" "/?page=2"}}}))
 
-       (fact "it transforms a resource with multiple links with same key into JSON"
-             (let [resource (-> resource
-                                (add-link :href "/admin" :rel "admin")
-                                (add-link :href "/?page=2" :rel "next")
-                                (add-link :href "/?page=3" :rel "next"))]
-               (json/parse-string (resource->representation resource :json))
-               => {"_links" {"self" {"href" "http://example.org"}
-                             "admin" {"href" "/admin"}
-                             "next" [{"href" "/?page=2"} {"href" "/?page=3"}]}}))
-
        (fact "it transforms a resource with multiple links into XML"
              (let [resource (-> resource
                                 (add-link :href "/admin" :rel "admin")
@@ -89,6 +79,29 @@
                     ["resource" {:href "http://example.org"}
                      ["link" {:href "/admin" :rel "admin"}]
                      ["link" {:href "/?page=2" :rel "next"}]]))))
+
+       (fact "it transforms a resource with multiple links with same key into JSON"
+             (let [resource (-> resource
+                                (add-link :href "/admin" :rel "admin")
+                                (add-link :href "/?page=2" :rel "next")
+                                (add-link :href "/?page=3" :rel "next"))]
+               (json/parse-string (resource->representation resource :json))
+               => {"_links" {"self" {"href" "http://example.org"}
+                             "admin" {"href" "/admin"}
+                             "next" [{"href" "/?page=2"} {"href" "/?page=3"}]}}))
+
+       (fact "it transforms a resource with multiple links with same key into XML"
+             (let [resource (-> resource
+                                (add-link :href "/admin" :rel "admin")
+                                (add-link :href "/?page=2" :rel "next")
+                                (add-link :href "/?page=3" :rel "next"))]
+               (resource->representation resource :xml)
+               => (xml/emit-str
+                   (xml/sexp-as-element
+                    ["resource" {:href "http://example.org"}
+                     ["link" {:href "/admin" :rel "admin"}]
+                     ["link" {:href "/?page=2" :rel "next"}]
+                     ["link" {:href "/?page=3" :rel "next"}]]))))
 
        (fact "it transforms a resource with properties into JSON"
              (let [resource (-> resource

--- a/test/halresource/resource_test.clj
+++ b/test/halresource/resource_test.clj
@@ -53,8 +53,7 @@
 (facts "about resource->representation"
        (fact "it transforms a simple resource into JSON"
              (json/parse-string (resource->representation resource :json))
-             => {"_links" [{"href" "http://example.org"
-                            "rel" "self"}]})
+             => {"_links" {"self" {"href" "http://example.org"}}})
 
        (fact "it transforms a simple resource into XML"
              (resource->representation resource :xml)
@@ -66,12 +65,19 @@
                                 (add-link :href "/admin" :rel "admin")
                                 (add-link :href "/?page=2" :rel "next"))]
                (json/parse-string (resource->representation resource :json))
-               => {"_links" [{"href" "http://example.org"
-                              "rel" "self"}
-                             {"href" "/admin"
-                              "rel" "admin"}
-                             {"href" "/?page=2"
-                              "rel" "next"}]}))
+               => {"_links" {"self" {"href" "http://example.org"}
+                             "admin" {"href" "/admin"}
+                             "next" {"href" "/?page=2"}}}))
+
+       (fact "it transforms a resource with multiple links with same key into JSON"
+             (let [resource (-> resource
+                                (add-link :href "/admin" :rel "admin")
+                                (add-link :href "/?page=2" :rel "next")
+                                (add-link :href "/?page=3" :rel "next"))]
+               (json/parse-string (resource->representation resource :json))
+               => {"_links" {"self" {"href" "http://example.org"}
+                             "admin" {"href" "/admin"}
+                             "next" [{"href" "/?page=2"} {"href" "/?page=3"}]}}))
 
        (fact "it transforms a resource with multiple links into XML"
              (let [resource (-> resource
@@ -88,8 +94,7 @@
              (let [resource (-> resource
                                 (add-property :size 200 :height 12))]
                (json/parse-string (resource->representation resource :json))
-               => {"_links" [{"href" "http://example.org"
-                              "rel" "self"}]
+               => {"_links" {"self" {"href" "http://example.org"}}
                    "size" 200
                    "height" 12}))
 
@@ -146,11 +151,10 @@
                                 (add-resource "dataset" (new-resource "/data/1"))
                                 (add-resource "dataset" (new-resource "/data/2")))]
                (json/parse-string (resource->representation resource :json))
-               => {"_links" [{"href" "http://example.org"
-                              "rel" "self"}]
+               => {"_links" {"self" {"href" "http://example.org"}}
                    "_embedded" {"datasets"
-                                [{"_links" [{"href" "/data/1" "rel" "self"}]}
-                                 {"_links" [{"href" "/data/2" "rel" "self"}]}]}}))
+                                [{"_links" {"self" {"href" "/data/1"}}}
+                                 {"_links" {"self" {"href" "/data/2"}}}]}}))
 
        (fact "it transforms a resource with embedded resources into XML"
              (let [resource (-> resource
@@ -171,17 +175,14 @@
                                                             (add-link :href "/data/3" :rel "next")))
                                 (add-property :size 200 :height 12))]
                (json/parse-string (resource->representation resource :json))
-               => {"_links" [{"href" "http://example.org"
-                              "rel" "self"}
-                             {"href" "/admin"
-                              "rel" "admin"}
-                             {"href" "/?page=2"
-                              "rel" "next"}]
+               => {"_links" {"self" {"href" "http://example.org"}
+                             "admin" {"href" "/admin"}
+                             "next" {"href" "/?page=2"}}
                    "_embedded" {"datasets"
-                                [{"_links" [{"href" "/data/1" "rel" "self"}]
+                                [{"_links" {"self" {"href" "/data/1"}}
                                   "name" "Pete"}
-                                 {"_links" [{"href" "/data/2" "rel" "self"}
-                                            {"href" "/data/3" "rel" "next"}]}]}
+                                 {"_links" {"self" {"href" "/data/2"}
+                                            "next" {"href" "/data/3"}}}]}
                    "size" 200
                    "height" 12}))
 


### PR DESCRIPTION
First of all, great work with this library!

According to the examples in

http://stateless.co/hal_specification.html

the _links section of a HAL-JSON should be represented by a JSON-object rather than a collection. Furthermore links with the same 'rel' should be an entry in the object with the 'rel' as key and a collection with all the hrefs as values. I don't know if this is a rule of any kind or just a matter of taste, but I like this representation better than the collection one.

These commits implements the JSON-representation in this way.
